### PR TITLE
fix: remove duplicated between_bytes_timeout

### DIFF
--- a/bluewin.vcl
+++ b/bluewin.vcl
@@ -11,7 +11,6 @@ backend delivery1 {
   .first_byte_timeout     = 10s; # How long to wait before we receive a first byte from our backend?
   .between_bytes_timeout  = 5s;  # Max time to wait for next package in an http response
   .connect_timeout        = 5s;  # How long to wait for a backend connection?
-  .between_bytes_timeout  = 2s;  # How long to wait between bytes received from our backend?
 }
 
 # Sport results custom pages source


### PR DESCRIPTION
I couldn't start Varnish due to the duplicated value and I think we defined it to 5s the other day:

```
Error:
Message from VCC-compiler:
Field 'between_bytes_timeout' redefined at:
('/etc/varnish/default.vcl' Line 14 Pos 4)
  .between_bytes_timeout  = 2s;  # How long to wait between bytes received from our backend?
---#####################--------------------------------------------------------------------


First defined at:
('/etc/varnish/default.vcl' Line 12 Pos 4)
  .between_bytes_timeout  = 5s;  # Max time to wait for next package in an http response
---#####################----------------------------------------------------------------

Running VCC-compiler failed, exited with 2
VCL compilation failed
``