### PR TITLE
Make the backend configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 env:
-  - VERSION=5.1.3-r0 NAME=varnish513 TAGS="livingdocs/bluewin-varnish:5.1.3 livingdocs/bluewin-varnish:latest"
+  - VERSION=5.1.3-r0 NAME=varnish513 TAGS="livingdocs/bluewin-varnish:5.1.3-r0 livingdocs/bluewin-varnish:latest"
 
 before_install:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 FROM alpine:edge
 
 ARG VERSION=5.1.3-r0
-RUN apk add --no-cache varnish=$VERSION && rm -rf /var/cache/apk/*
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories
+RUN apk add --no-cache tini gomplate varnish=$VERSION && rm -rf /var/cache/apk/*
 
 ENV VARNISH_CONFIG '/etc/varnish/default.vcl'
+ENV VARNISH_CONFIG_TEMPLATE '/etc/varnish/default.vcl.tmpl'
 ENV VARNISH_CACHE_SIZE 512m
 ENV VARNISH_PORT 80
 
 EXPOSE $VARNISH_PORT
 
 COPY entrypoint.sh /entrypoint.sh
-COPY bluewin.vcl $VARNISH_CONFIG
+COPY bluewin.vcl.tmpl $VARNISH_CONFIG_TEMPLATE
 
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -18,14 +18,13 @@ All configuration is done via environment variables.
 
 ### Run
 
-* `BACKEND_HOST` -- the IP address or hostname of the delivery server
-* `BACKEND_PORT` -- the HTTP port of the delivery server
+* `BACKEND` the hostname:port of the backend, supports comma delimited values
 
 
 ## Create a container and give it a name
 
 ```bash
-docker run -p 80:80 --env BACKEND_HOST=127.0.0.1 --env BACKEND_PORT=9090 --name varnish livingdocs/varnish
+docker run -p 80:80 --env BACKEND=backend:9090 --name varnish livingdocs/varnish
 ```
 
 ## Start an existing container

--- a/bluewin.vcl.tmpl
+++ b/bluewin.vcl.tmpl
@@ -3,15 +3,27 @@ vcl 4.0;
 import std;
 import directors;
 
-backend delivery1 {
-  .host = "{{BACKEND_HOST}}";
-  .port = "{{BACKEND_PORT}}";
+probe backend_healthcheck {
+  .url = "/status";
+  .interval = 2s;
+  .timeout = 1s;
+  .window = 3;
+  .threshold = 2;
+}
+
+{{ range $index, $hostname := (split .Env.BACKEND ",") }}
+backend delivery_{{ $index }} {
+  {{- $backend := ($hostname | strings.Split ":") }}
+  .host = "{{ index $backend 0 }}";
+  .port = "{{ index $backend 1 }}";
 
   .max_connections        = 75;
   .first_byte_timeout     = 10s; # How long to wait before we receive a first byte from our backend?
   .between_bytes_timeout  = 5s;  # Max time to wait for next package in an http response
   .connect_timeout        = 5s;  # How long to wait for a backend connection?
+  .probe = backend_healthcheck;
 }
+{{ end }}
 
 # Sport results custom pages source
 backend sportdaten {
@@ -23,6 +35,13 @@ acl purge {
   "localhost";
   "127.0.0.1";
   "::1";
+}
+
+sub vcl_init {
+    new delivery = directors.round_robin();
+    {{- range $index, $backend := (split .Env.BACKEND ",") }}
+    delivery.add_backend(delivery_{{ $index }});
+    {{- end }}
 }
 
 sub vcl_recv {
@@ -38,7 +57,7 @@ sub vcl_recv {
     set req.backend_hint = sportdaten;
   }
   else {
-    set req.backend_hint = delivery1;
+    set req.backend_hint = delivery.backend();
   }
 
   # Remove the proxy header (see https://httpoxy.org/#mitigate-varnish)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,9 @@
 #!/bin/sh
 set -e
 
-if hash gsed 2>/dev/null; then
-  alias sed=gsed
+if [ ! -f $VARNISH_CONFIG ]; then
+  gomplate --file $VARNISH_CONFIG_TEMPLATE > $VARNISH_CONFIG
 fi
 
-sed -i.original "s|{{BACKEND_HOST}}|${BACKEND_HOST}|g" $VARNISH_CONFIG
-sed -i.original "s|{{BACKEND_PORT}}|${BACKEND_PORT}|g" $VARNISH_CONFIG
-
-varnishd -f $VARNISH_CONFIG -s malloc,$VARNISH_CACHE_SIZE -a 0.0.0.0:${VARNISH_PORT} -T 0.0.0.0:2000 -p feature=+http2
+varnishd -f $VARNISH_CONFIG -s malloc,$VARNISH_CACHE_SIZE -a 0.0.0.0:$VARNISH_PORT -T 0.0.0.0:2000 -p feature=+http2
 varnishncsa -F '{"@timestamp":"%{%Y-%m-%dT%H:%M:%S%z}t","method":"%m","url":"%U","remote_ip":"%h","x_forwarded_for":"%{X-Forwarded-For}i","cache":"%{Varnish:handling}x","bytes":%b,"duration_usec":%D,"status":%s,"request":"%r","ttfb":"%{Varnish:time_firstbyte}x","referrer":"%{Referrer}i","user_agent":"%{User-agent}i"}'


### PR DESCRIPTION
`docker run --rm -it -e BACKEND=first:8080,second:8080 livingdocs/bluewin-varnish`

Currently the healthcheck is also hardcoded on `/status`