### PR TITLE
Upgrade to varnish 6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
     password:
       from_secret: docker_password
     repo: livingdocs/varnish
-    tags: [5.2.1-r6, latest]
+    tags: [6.1.1-r0, latest]
 
 - name: publish
   image: plugins/docker
@@ -22,7 +22,7 @@ steps:
     password:
       from_secret: docker_password
     repo: livingdocs/varnish
-    tags: [5.2.1-r6, latest]
+    tags: [6.1.1-r0, latest]
 
   when:
     branch: [master]
@@ -32,6 +32,6 @@ trigger:
 
 ---
 kind: signature
-hmac: b2cafbacc284d4ec33aaa3841d0ebe65cb2668338a940c910c328e317286dd21
+hmac: ab382047fc1e496efffbc5fd5ba3705396485ed0dcd566db909fe1b34e46aec5
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.2-alpine3.6 as go
+FROM golang:1.11.5-alpine3.9 as go
 RUN apk add --no-cache git
 RUN go get -d github.com/jonnenauha/prometheus_varnish_exporter github.com/marcbachmann/exitd github.com/kelseyhightower/confd
 RUN cd /go/src/github.com/jonnenauha/prometheus_varnish_exporter && git checkout 1.3.4 && go build -ldflags "-X 'main.Version=1.3.4' -X 'main.VersionHash=$(git rev-parse --short HEAD)' -X 'main.VersionDate=$(date -u '+%d.%m.%Y %H:%M:%S')'" -o /go/bin/prometheus_varnish_exporter
@@ -6,8 +6,8 @@ RUN cd /go/src/github.com/marcbachmann/exitd && git checkout master && go build 
 RUN cd /go/src/github.com/kelseyhightower/confd && git checkout v0.15.0 && go build -ldflags "-X 'main.GitSHA=$(git rev-parse --short HEAD)'"  -o /go/bin/confd
 RUN ls -lisa /go/bin
 
-FROM alpine:3.7
-ENV VARNISH_VERSION=5.2.1-r0
+FROM alpine:3.9
+ENV VARNISH_VERSION=6.1.1-r0
 
 RUN apk add --no-cache tini varnish=$VARNISH_VERSION ca-certificates bind-tools
 COPY --from=go /go/bin/* /bin/

--- a/default.vcl.tmpl
+++ b/default.vcl.tmpl
@@ -1,4 +1,4 @@
-vcl 4.0;
+vcl 4.1;
 
 import std;
 import directors;
@@ -129,7 +129,6 @@ sub vcl_recv {
     set req.url = regsuball(req.url, "&(utm_source|utm_medium|utm_campaign|utm_content|gclid|cx|ie|cof|siteurl)=([A-z0-9_\-\.%25]+)", "");
     set req.url = regsuball(req.url, "\?(utm_source|utm_medium|utm_campaign|utm_content|gclid|cx|ie|cof|siteurl)=([A-z0-9_\-\.%25]+)", "?");
     set req.url = regsub(req.url, "\?&", "?");
-    set req.url = regsub(req.url, "\?$", "");
   }
 
   # Strip hash, server doesn't need it.


### PR DESCRIPTION
BREAKING CHANGE: Varnish 6 dropped some old configurations.
It won't affect customers which used the vcl of this docker image.

Others should check their configuration against the varnish 6 release notes
https://varnish-cache.org/docs/6.0/whats-new/changes-6.0.html