### PR TITLE
Fix config reloads and add xkey support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
     password:
       from_secret: docker_password
     repo: livingdocs/varnish
-    tags: [6.3.1-r0, latest]
+    tags: [6.3.1-r1, latest]
 
 - name: publish
   image: plugins/docker
@@ -22,7 +22,7 @@ steps:
     password:
       from_secret: docker_password
     repo: livingdocs/varnish
-    tags: [6.3.1-r0, latest]
+    tags: [6.3.1-r1, latest]
 
   when:
     branch: [master]
@@ -32,6 +32,6 @@ trigger:
 
 ---
 kind: signature
-hmac: a93d92c45daa72a46659202b0700bf3d20187e6f27f86b8270b67b66e9c51bad
+hmac: e79f0939b2e6a1a0d9bd9437eba31ba96b3de60d258383f3323fe331b179ff97
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,14 @@ FROM alpine:3.10
 ENV VARNISH_VERSION=6.3.1-r0
 
 RUN apk add --no-cache tini ca-certificates bind-tools nano curl && \
-  apk add --no-cache varnish=$VARNISH_VERSION --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+  apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main --no-cache varnish=$VARNISH_VERSION && \
+  apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main --virtual build-dependencies --no-cache git libgit2-dev automake varnish-dev=$VARNISH_VERSION autoconf libtool py-docutils make \
+    && git clone https://github.com/varnish/varnish-modules.git --depth='1' --branch='6.3' --single-branch /varnish-modules \
+    && cd /varnish-modules \
+    && ./bootstrap && ./configure && make && make install \
+    && apk del build-dependencies \
+    && rm -Rf /varnish-modules
+
 COPY --from=go /go/bin/* /bin/
 
 ENV VARNISH_CONFIG='/etc/varnish/default.vcl'

--- a/bin/varnish
+++ b/bin/varnish
@@ -9,7 +9,7 @@ fi
 
 function durationToSeconds () {
   set -f
-  normalize () { echo $1 | tr '[:upper:]' '[:lower:]' | tr -d "\"\\\'" | sed 's/ *y\(ear\)\{0,1\} */y /g; s/ *d\(ay\)\{0,1\} */d /g; s/ *h\(our\)\{0,1\} */h /g; s/ *m\(in\(ute\)\{0,1\}\)\{0,1\} */m /g; s/ *s\(ec\(ond\)\{0,1\}\)\{0,1\} */s /g; s/\([ydhms]\)s/\1/g'; }
+  normalize () { echo $1 | tr '[:upper:]' '[:lower:]' | tr -d "\"\\\'" | sed 's/ *\(years\|year\|y\) */y /g; s/ *\(days\|day\|d\) */d /g; s/ *\(hours\|hour\|h\) */h /g; s/ *\(minutes\|minute\|min\|m\) */m /g; s/ *\(seconds\|second\|sec\|s\) */s /g; s/\([a-z]\) s/\1 /g;'; }
   local value=$(normalize "$1")
   local fallback=$(normalize "$2")
 

--- a/bin/varnish-reload-vcl
+++ b/bin/varnish-reload-vcl
@@ -4,9 +4,30 @@ ADMIN=localhost:$VARNISH_ADMIN_PORT
 NAME="varnish_$(date +%s)"
 
 function error () {
-  echo 1>&2 "Failed to reload $FILE."
+  echo 1>&2 $1
   exit 1
 }
 
-varnishadm -T $ADMIN -S /etc/varnish/secret vcl.load $NAME $FILE || error
-varnishadm -T $ADMIN -S /etc/varnish/secret vcl.use $NAME || error
+varnishadm() {
+  if ! OUTPUT=$(command varnishadm -T $ADMIN -S /etc/varnish/secret -- "$@" 2>&1)
+  then
+    echo "Command: varnishadm -T $ADMIN -S /etc/varnish/secret -- $*"
+    echo
+    echo "$OUTPUT"
+    echo
+    return 1
+  fi >&2
+  echo "$OUTPUT"
+}
+
+varnishadm vcl.load $NAME $FILE || error "Failed to vcl.load $FILE."
+sleep 5
+
+varnishadm vcl.use $NAME || error "Failed to vcl.use $FILE."
+sleep 5
+
+INACTIVE_VCLS=$(varnishadm vcl.list | awk '/(auto|cold)\/cold/ {print $4}') || error "Failed to get the vcl list."
+for vclname in $INACTIVE_VCLS; do
+  echo "Call varnishadm vcl.discard $vclname"
+  varnishadm vcl.discard $vclname 1>/dev/null || error "Failed to vcl.discard $vclname."
+done;

--- a/default.vcl.tmpl
+++ b/default.vcl.tmpl
@@ -56,7 +56,9 @@ acl purge {
   "localhost";
   "127.0.0.1";
   "::1";
-  "172.17.0.0/24";
+  "172.17.0.0/24"; # Docker Network range
+  "212.51.140.235"; # Livingdocs
+  "212.51.155.165"; # Marc
 }
 
 sub vcl_init {

--- a/default.vcl.tmpl
+++ b/default.vcl.tmpl
@@ -2,6 +2,7 @@ vcl 4.1;
 
 import std;
 import directors;
+import xkey;
 
 {{ $BACKENDS := (split (getenv "BACKEND") ",") }}
 {{ $REMOTE_BACKENDS := (split (getenv "REMOTE_BACKEND") ",") }}
@@ -98,7 +99,13 @@ sub vcl_recv {
     if (!client.ip ~ purge) {
       return (synth(405, "This IP is not allowed to send PURGE requests."));
     }
-    return (purge);
+
+    if (req.http.xkey) {
+      set req.http.n-gone = xkey.softpurge(req.http.xkey);
+      return (synth(200, "Invalidated "+req.http.n-gone+" objects"));
+    } else {
+      return (purge);
+    }
   }
 
   # Support websockets

--- a/default.vcl.tmpl
+++ b/default.vcl.tmpl
@@ -27,6 +27,7 @@ backend backend_{{ $backendIndex }}_{{ $ipIndex }} {
     .timeout = {{ getenv "BACKEND_PROBE_TIMEOUT" }};
     .window = {{ getenv "BACKEND_PROBE_WINDOW" }};
     .threshold = {{ getenv "BACKEND_PROBE_THRESHOLD" }};
+    .initial = {{ getenv "BACKEND_PROBE_THRESHOLD" }};
   }
   {{ end }}
 }


### PR DESCRIPTION
- Bundle varnish-modules in the docker image.
- Add xkey support to the default vcl
- Fix configuration reloads where a backend was down at first

Publish as `livingdocs/varnish:6.3.1-r1`