### PR TITLE
Proper signal handling and /_health endpoint that supports graceful shutdowns

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
     password:
       from_secret: docker_password
     repo: livingdocs/varnish
-    tags: [6.3.1-r5, latest]
+    tags: [6.3.1-r6, latest]
 
 - name: publish
   image: plugins/docker
@@ -22,7 +22,7 @@ steps:
     password:
       from_secret: docker_password
     repo: livingdocs/varnish
-    tags: [6.3.1-r5, latest]
+    tags: [6.3.1-r6, latest]
 
   when:
     branch: [master]
@@ -32,6 +32,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 708abea9dd6c094f313b499db116846220364831160cb063e3bcd6446acaf545
+hmac: 3632633649db904513637dd5510b55e32909df6ea1c46abdcd9bb5ade6127396
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN ls -lisa /go/bin
 FROM alpine:3.10
 ENV VARNISH_VERSION=6.3.1-r1
 
-RUN apk add --no-cache bash tini ca-certificates bind-tools nano curl && \
+RUN apk add --no-cache bash ca-certificates bind-tools nano curl tini procps && \
   apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main --no-cache varnish=$VARNISH_VERSION && \
   apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main --virtual build-dependencies --no-cache git libgit2-dev automake varnish-dev=$VARNISH_VERSION autoconf libtool py-docutils make \
     && git clone https://github.com/varnish/varnish-modules.git --depth='1' --branch='6.3' --single-branch /varnish-modules \
@@ -32,5 +32,5 @@ COPY ./bin/* /bin/
 EXPOSE $VARNISH_PORT
 EXPOSE $VARNISH_ADMIN_PORT
 EXPOSE $PROMETHEUS_EXPORTER_PORT
-ENTRYPOINT ["/sbin/tini", "-g", "--"]
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/entrypoint.sh"]

--- a/bin/prometheus-varnish-exporter
+++ b/bin/prometheus-varnish-exporter
@@ -1,3 +1,3 @@
 #!/bin/sh
-sleep 5
-exec prometheus_varnish_exporter -web.listen-address :$PROMETHEUS_EXPORTER_PORT
+sleep 3
+exec prometheus_varnish_exporter -web.listen-address :$PROMETHEUS_EXPORTER_PORT 1>&2

--- a/bin/varnish
+++ b/bin/varnish
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 exec varnishd -F -f $VARNISH_CONFIG \
   -S $VARNISH_ADMIN_SECRET_FILE \
   -s malloc,$VARNISH_CACHE_SIZE \
@@ -15,4 +14,5 @@ exec varnishd -F -f $VARNISH_CONFIG \
   -p http_resp_size=262144 \
   -p shortlived=360 \
   -p workspace_backend=128k \
+  -p syslog_cli_traffic=off \
   $VARNISH_RUNTIME_PARAMETERS 1>&2

--- a/bin/varnish-logs
+++ b/bin/varnish-logs
@@ -1,2 +1,3 @@
 #!/bin/sh
+sleep 3
 exec varnishncsa -t off -F '{"@timestamp":"%{%Y-%m-%dT%H:%M:%S%z}t","method":"%m","url":"%U","remote_ip":"%h","x_forwarded_for":"%{X-Forwarded-For}i","cache":"%{Varnish:handling}x","bytes":"%b","duration_usec":"%D","status":"%s","request":"%r","ttfb":"%{Varnish:time_firstbyte}x","referrer":"%{Referrer}i","user_agent":"%{User-agent}i"}'

--- a/bin/varnish-reload-vcl
+++ b/bin/varnish-reload-vcl
@@ -5,28 +5,28 @@ ADMIN=localhost:$VARNISH_ADMIN_PORT
 NAME="varnish_$(date +%s)"
 
 function error () {
-  echo 1>&2 $1
+  >&2 echo $1
   exit 1
 }
 
 varnishadm() {
   if ! OUTPUT=$(command varnishadm -T $ADMIN -S $VARNISH_ADMIN_SECRET_FILE -- "$@" 2>&1)
   then
-    echo "Command: varnishadm -T $ADMIN -S $VARNISH_ADMIN_SECRET_FILE -- $*"
-    echo
-    echo "$OUTPUT"
-    echo
+    >&2 echo "Command: varnishadm -T $ADMIN -S $VARNISH_ADMIN_SECRET_FILE -- $*"
+    >&2 echo
+    >&2 echo "$OUTPUT"
+    >&2 echo
     return 1
   fi >&2
   echo "$OUTPUT"
 }
 
-varnishadm vcl.load $NAME $FILE || error "Failed to vcl.load $FILE."
-varnishadm vcl.use $NAME || error "Failed to vcl.use $FILE."
+>&2 varnishadm vcl.load $NAME $FILE || error "Failed to vcl.load $FILE."
+>&2 varnishadm vcl.use $NAME || error "Failed to vcl.use $FILE."
 sleep 10
 
 INACTIVE_VCLS=$(varnishadm vcl.list | awk '/(auto|cold)\/cold/ {print $4}') || error "Failed to get the vcl list."
 for vclname in $INACTIVE_VCLS; do
-  echo "Call varnishadm vcl.discard $vclname"
+  >&2 echo "Call varnishadm vcl.discard $vclname"
   varnishadm vcl.discard $vclname 1>/dev/null || error "Failed to vcl.discard $vclname."
 done;

--- a/default.vcl.tmpl
+++ b/default.vcl.tmpl
@@ -1,8 +1,13 @@
+{{- define "vstr" -}}
+"{{ replace (replace (replace . `"` `" + {"""} + "` -1) `${` `" +` -1) `}$` `+ "` -1}}"
+{{- end }}
+
 vcl 4.1;
 
 import std;
 import directors;
 import xkey;
+import var;
 
 {{ if eq (getenv "BACKEND_PROBE") "true" }}
 probe delivery_probe {
@@ -88,6 +93,8 @@ acl purge {
 }
 
 sub vcl_init {
+  var.global_set("health", "200");
+
   new delivery = directors.round_robin();
   {{- range $backendIndex, $hostnameWithPort := $BACKENDS -}}
     {{- $backend := (split $hostnameWithPort ":") -}}
@@ -110,6 +117,20 @@ sub vcl_init {
 }
 
 sub vcl_recv {
+  if (req.url == "/_health") {
+    set req.http.status = var.global_get("health");
+
+    if (req.method == "POST") {
+      if (client.ip ~ purge) {
+        var.global_set("health", req.http.health);
+      } else {
+        return (synth(405, "The IP '" + client.ip + "' is not allowed to send a POST /_health request."));
+      }
+    }
+
+    return (synth(222, req.http.status));
+  }
+
   # Allow purging
   if (req.method == "BAN") {
     # purge is an ACL defined above, we check the ip is in there
@@ -355,16 +376,15 @@ sub vcl_synth {
   if (resp.status == 503 && req.http.host != "error") {
     if (resp.http.Follow-Error-Status) {set req.http.Error-Status = resp.http.Follow-Error-Status;}
     else {set req.http.Error-Status = resp.status;}
-    return(restart);
+    return (restart);
   } else if (resp.status == 301) {
     set resp.http.location = resp.reason;
-    set resp.reason = "Moved Permanently";
   } else if (resp.status == 302) {
     set resp.http.location = resp.reason;
-    set resp.reason = "Moved Temporarily";
   } else if (resp.status == 307) {
     set resp.http.location = resp.reason;
-    set resp.reason = "Temporary Redirect";
+  } else if (resp.status == 222) {
+    set resp.status = std.integer(resp.reason, 503);
   }
 
   set resp.http.X-Served-By = "{{getenv "HOSTNAME_PREFIX" ""}}{{getenv "HOSTNAME"}}";
@@ -374,10 +394,13 @@ sub vcl_synth {
 
   if (req.http.Content-Type ~ "application/json") {
     set resp.http.Content-Type = "application/json; charset=utf-8";
-    synthetic(regsub(regsub(regsuball("{'status':_s,'error':'_e'}", "'", {"""}), "_s", resp.status), "_e", resp.reason));
-  } else {
+    set resp.body = {{ template "vstr" `{"status":${resp.status}$,"error":"${resp.reason}$"}`}};
+  } else if (req.http.Content-Type ~ "text/html") {
     set resp.http.Content-Type = "text/html; charset=utf-8";
-    synthetic({"<!DOCTYPE html><html><head><title>"} + resp.status + " " + resp.reason + {"</title></head><body><h1>"} + resp.status + " " + resp.reason + {"</h1></body></html>"});
+    set resp.body = {{ template "vstr" `<!DOCTYPE html><html><head><title>${resp.status}$ ${resp.reason}$</title></head><body><h1>${resp.status}$ ${resp.reason}$</h1></body></html>`}};
+  } else {
+    set resp.http.Content-Type = "text/plain; charset=utf-8";
+    set resp.body = {{ template "vstr" `${resp.status}$ ${resp.reason}$` }};
   }
 
   return (deliver);

--- a/varnish.toml
+++ b/varnish.toml
@@ -1,4 +1,5 @@
 [template]
+log-level = "error"
 src = "varnish.vcl.tmpl"
 dest = "/etc/varnish/default.vcl"
 check_cmd = "varnishd -C -f {{.src}}"


### PR DESCRIPTION
We have a `/_health` endpoint that can be configured in an edge loadbalancer to detect whether the varnish instance is shutting down.

E.g. to take varnish out of the loadbalancer, you can execute a `curl -XPOST -H 'health: 503' http://localhost:$VARNISH_PORT/_health` request that only configures the `/_health` endpoint to return the `503` error. Varnish still keeps running and doesn't take any action on a backend.

We use this when a `SIGTERM` signal is sent to the `pid 1` to initiate a graceful shutdown.
Long running requests will still result in failures if the varnish instance isn't taken out of a loadbalancer.
